### PR TITLE
Add script to fetch files in manifest copydef

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ out working in Sugar.
 
 - [sugar-manifest.rb](./sugar-manifest.rb)
 
-  Generates a boilerplate manifest.php file. If a list of filenames is used as an argument
-  it will also create the copy block under the installdefs section.
+  Generates a boilerplate manifest.php file. If a list of filenames
+  is used as an argument it will also create the copy block under
+  the installdefs section.
 
+- [sugar-packer.rb](./sugar-packer.rb)
+
+  Reads from a manifest.php file and attempts fetch all the listed files
+  necessary for the Module Loader package.
 
 
 ## License

--- a/sugar-packer.rb
+++ b/sugar-packer.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require 'FileUtils'
+
+manifest = 'manifest.php'
+
+def package_file(filename)
+  source_file = "../../" + filename
+
+  if File.file?(source_file)
+    destination = File.dirname(filename)
+    FileUtils.mkdir_p(destination)
+    File.write(filename, File.read(source_file))
+
+    puts '+ ' + filename
+  end
+end
+
+unless File.file?(manifest)
+  print "Missing " + manifest + " to read from\n"
+  exit(1)
+end
+
+unless File.open(manifest).read().include? "basepath"
+  print "No <basepath> lines to read from manifest\n"
+  exit(1)
+end
+
+lines = File.readlines(manifest).grep /basepath/
+
+lines.each do |line|
+  filename = line.match(/'from' => '<basepath>\/(custom\/[a-zA-Z\/_\-]+.php)/)
+  package_file(filename[1])
+end
+


### PR DESCRIPTION
The attempt is based on finding the custom directory supposedly
listed two parent directories away. If the files are there, then
copy them to the current location (current to manifest.php) and
build out the necessary directory trees along the way.