### PR TITLE
Allow digits to be present in filenames

### DIFF
--- a/sugar-packer.rb
+++ b/sugar-packer.rb
@@ -31,7 +31,7 @@ end
 lines = File.readlines(manifest).grep /basepath/
 
 lines.each do |line|
-  filename = line.match(/'from' => '<basepath>\/(custom\/[a-zA-Z\/_\-.]+)'/)
+  filename = line.match(/'from' => '<basepath>\/(custom\/[a-zA-Z0-9\/_\-.]+)'/)
   package_file(filename[1])
 end
 


### PR DESCRIPTION
Because sometimes a file may use a digit and not just letters